### PR TITLE
Fix -dflambda argument

### DIFF
--- a/middle_end/middle_end.ml
+++ b/middle_end/middle_end.ml
@@ -173,7 +173,7 @@ let middle_end ppf ~source_provenance ~prefixname ~backend
             (Warnings.Inlining_impossible "[@unroll] attribute was not \
               used on this function application (the optimizer did not \
               know what function was being applied)"));
-    if !Clflags.dump_rawflambda
+    if !Clflags.dump_flambda
     then
       Format.fprintf ppf "End of middle end:@ %a@."
         Flambda.print_program flam;


### PR DESCRIPTION
There is a typo preventing the right use of -dflambda from working correcly.
This change a test from checking if -drawflambda is activated to -dflambda.
